### PR TITLE
Update CircleCI workflow to publish from 1.19.2 branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,13 +115,13 @@ workflows:
           filters:
             branches:
               ignore:
-                - master
+                - 1.19.2
           requires:
             - version
       - build_publish:
           filters:
             branches:
               only:
-                - master
+                - 1.19.2
           requires:
             - version


### PR DESCRIPTION
- Change build job to ignore 1.19.2 (instead of master)
- Change build_publish job to only run on 1.19.2 (instead of master)
- Allows publishing releases directly from version branch