### PR TITLE
Fix Forge version to match Minecraft 1.19.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,7 @@ repositories {
 }
 
 dependencies {
-    minecraft 'net.minecraftforge:forge:1.19-41.1.0'
+    minecraft 'net.minecraftforge:forge:1.19.2-43.3.0'
 }
 
 jar {


### PR DESCRIPTION
- Update from forge:1.19-41.1.0 to forge:1.19.2-43.3.0
- Fixes CurseForge upload error (version ID mismatch)
- Aligns with minecraft_version=1.19.2 in gradle.properties