### PR TITLE
Update curse_gradle_uploader to version 1.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         maven { url = 'https://repo.u-team.info' }
     }
     dependencies {
-        classpath 'info.u-team.curse_gradle_uploader:curse_gradle_uploader:1.5.0'
+        classpath 'info.u-team.curse_gradle_uploader:curse_gradle_uploader:1.6.0'
         classpath 'com.github.breadmoirai:github-release:2.3.7'
     }
 }


### PR DESCRIPTION
- Upgrade from 1.5.0 to 1.6.0
- May fix CurseForge upload errors with game version IDs
- Latest version from MC-U-Team repository