### PR TITLE
Add CurseForge and GitHub publishing for multi-platform build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,21 @@
+buildscript {
+    repositories {
+        maven { url = 'https://repo.u-team.info' }
+    }
+    dependencies {
+        classpath 'info.u-team.curse_gradle_uploader:curse_gradle_uploader:1.6.0'
+        classpath 'com.github.breadmoirai:github-release:2.3.7'
+    }
+}
+
 plugins {
     id 'dev.architectury.loom' version '1.13-SNAPSHOT' apply false
     id 'architectury-plugin' version '3.4-SNAPSHOT'
     id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
+    id 'com.github.breadmoirai.github-release' version '2.3.7'
 }
+
+apply plugin: 'info.u_team.curse_gradle_uploader'
 
 architectury {
     minecraft = project.minecraft_version
@@ -83,5 +96,58 @@ subprojects {
             // The repositories here will be used for publishing your artifact, not for
             // retrieving dependencies.
         }
+    }
+}
+
+// CurseForge publishing for multi-platform artifacts
+curseforge {
+    apiKey = System.getenv('CURSE_API_KEY') ?: ''
+
+    // Fabric artifact
+    project {
+        id = project.hasProperty('curse_project_id') ? curse_project_id : ''
+        changelog = file('CHANGELOG.md')
+        releaseType = project.hasProperty('curse_release_type') ? curse_release_type : 'release'
+
+        addGameVersion '1.21.1'
+        addGameVersion 'Fabric'
+
+        mainArtifact(file("fabric/build/libs/devworld-fabric-${project.version}.jar")) {
+            displayName = "DevWorld ${project.version} (Fabric)"
+        }
+    }
+
+    // NeoForge artifact
+    project {
+        id = project.hasProperty('curse_project_id') ? curse_project_id : ''
+        changelog = file('CHANGELOG.md')
+        releaseType = project.hasProperty('curse_release_type') ? curse_release_type : 'release'
+
+        addGameVersion '1.21.1'
+        addGameVersion 'NeoForge'
+
+        mainArtifact(file("neoforge/build/libs/devworld-neoforge-${project.version}.jar")) {
+            displayName = "DevWorld ${project.version} (NeoForge)"
+        }
+    }
+}
+
+// GitHub Release publishing
+String readChangelogString(String filePath) {
+    File file = new File(filePath)
+    if(file.exists()) {
+        return file.text
+    }
+    return ""
+}
+
+githubRelease {
+    token System.getenv("GITHUB_TOKEN") ?: "InvalidP@ssword"
+    owner System.getenv("CIRCLE_PROJECT_USERNAME") ?: ""
+    repo System.getenv("CIRCLE_PROJECT_REPONAME") ?: ""
+    targetCommitish = System.getenv("CIRCLE_SHA1") ?: ""
+    releaseAssets file("fabric/build/libs").listFiles(), file("neoforge/build/libs").listFiles()
+    body {
+        return readChangelogString("CHANGELOG.md")
     }
 }


### PR DESCRIPTION
- Add curse_gradle_uploader 1.6.0 plugin
- Configure separate uploads for Fabric and NeoForge artifacts
- Each upload tagged with correct mod loader (Fabric/NeoForge)
- Both use Minecraft 1.21.1 version tag
- GitHub releases include both platform JARs
- Uses CURSE_API_KEY and GITHUB_TOKEN from environment