### PR TITLE
Fix version string to use clean git tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - run:
           name: "Calculate the next version"
           command: |
-            export NEW_VERSION=$(docker run --rm -v $(pwd):/repo codacy/git-version)
+            export NEW_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
             echo $NEW_VERSION > CI_VERSION
             echo $NEW_VERSION
       - persist_to_workspace:


### PR DESCRIPTION
- Replace codacy/git-version with simple git describe
- Removes verbose metadata from version (commit hash, branch info)
- Version format: 0.0.6 instead of 0.0.7-00611g2f09ca7.11.sha.2f09ca7
- Falls back to 0.0.0 if no tags exist