### PR TITLE
Fix version string to extract only semver from git-version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,11 @@ jobs:
       - run:
           name: "Calculate the next version"
           command: |
-            export NEW_VERSION=$(docker run --rm -v $(pwd):/repo codacy/git-version)
+            FULL_VERSION=$(docker run --rm -v $(pwd):/repo codacy/git-version)
+            export NEW_VERSION=$(echo $FULL_VERSION | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
             echo $NEW_VERSION > CI_VERSION
-            echo $NEW_VERSION
+            echo "Full version: $FULL_VERSION"
+            echo "Clean version: $NEW_VERSION"
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
- Keep codacy/git-version tool for version calculation
- Extract only semantic version (X.Y.Z) from output
- Strips extra metadata (commit hash, branch info, SHA)
- Version format: 0.0.7 instead of 0.0.7-00611g2f09ca7.11.sha.2f09ca7