### PR TITLE
Fix version string to extract only semver from git-version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
           command: |
             git clone --branch $CIRCLE_BRANCH https://github.com/FireBall1725/DevWorld3.git .
             git checkout $CIRCLE_SHA1
+            git fetch --tags
       - run:
           name: "Calculate the next version"
           command: |
@@ -41,6 +42,7 @@ jobs:
           command: |
             git clone --branch $CIRCLE_BRANCH https://github.com/FireBall1725/DevWorld3.git .
             git checkout $CIRCLE_SHA1
+            git fetch --tags
       - attach_workspace:
           at: .
       - run:
@@ -71,6 +73,7 @@ jobs:
           command: |
             git clone --branch $CIRCLE_BRANCH https://github.com/FireBall1725/DevWorld3.git .
             git checkout $CIRCLE_SHA1
+            git fetch --tags
       - attach_workspace:
           at: .
       - run:


### PR DESCRIPTION
## Changes
- Keep codacy/git-version tool for version calculation
- Extract only semantic version (X.Y.Z) from output
- Strips extra metadata (commit hash, branch info, SHA)
- Fetch git tags for version calculation

## Before
`DevWorld3-1.20.1-0.0.7-00611g2f09ca7.11.sha.2f09ca7-client.jar`

## After
`DevWorld3-1.20.1-0.0.7-client.jar`

Fixes version format to use clean semver instead of verbose git metadata.