### PR TITLE
Fix version string to extract only semver from git-version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
           command: |
             git clone --branch $CIRCLE_BRANCH https://github.com/FireBall1725/DevWorld3.git .
             git checkout $CIRCLE_SHA1
+            git fetch --tags
       - run:
           name: "Calculate the next version"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,11 @@ jobs:
       - run:
           name: "Calculate the next version"
           command: |
-            export NEW_VERSION=$(docker run --rm -v $(pwd):/repo codacy/git-version)
+            FULL_VERSION=$(docker run --rm -v $(pwd):/repo codacy/git-version)
+            export NEW_VERSION=$(echo $FULL_VERSION | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
             echo $NEW_VERSION > CI_VERSION
-            echo $NEW_VERSION
+            echo "Full version: $FULL_VERSION"
+            echo "Clean version: $NEW_VERSION"
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ jobs:
           command: |
             git clone --branch $CIRCLE_BRANCH https://github.com/FireBall1725/DevWorld3.git .
             git checkout $CIRCLE_SHA1
+            git fetch --tags
       - attach_workspace:
           at: .
       - run:
@@ -75,6 +76,7 @@ jobs:
           command: |
             git clone --branch $CIRCLE_BRANCH https://github.com/FireBall1725/DevWorld3.git .
             git checkout $CIRCLE_SHA1
+            git fetch --tags
       - attach_workspace:
           at: .
       - run:


### PR DESCRIPTION
## Summary
Fixes version string pollution in JAR filenames by extracting only the semantic version number from codacy/git-version output.

## Changes
- Modified `.circleci/config.yml` version job to extract clean semver (X.Y.Z) from git-version output
- Added `git fetch --tags` to ensure tags are available for version calculation
- Uses `grep -oE '^[0-9]+\.[0-9]+\.[0-9]+'` to extract only the semver portion

## Before
```
DevWorld3-1.21.1-4.0.0-00611g2f09ca7.11.sha.2f09ca7-fabric.jar
```

## After
```
DevWorld3-1.21.1-4.0.0-fabric.jar
```

## Testing
- Verified version calculation step extracts clean semver
- Build artifacts use clean version string