### PR TITLE
Fix CurseForge and GitHub Release publishing for multi-module project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,34 +99,37 @@ subprojects {
 
 apply plugin: 'info.u_team.curse_gradle_uploader'
 
-curseforge {
-    apiKey = System.getenv('CURSE_API_KEY') ?: ''
+// Configure after evaluation to ensure subproject tasks are available
+afterEvaluate {
+    curseforge {
+        apiKey = System.getenv('CURSE_API_KEY') ?: ''
 
-    // Fabric artifact
-    project {
-        id = curse_project_id
-        changelog = file('CHANGELOG.md')
-        releaseType = curse_release_type
+        // Fabric artifact
+        project {
+            id = curse_project_id
+            changelog = file('CHANGELOG.md')
+            releaseType = curse_release_type
 
-        addGameVersion minecraft_version
-        addGameVersion 'Fabric'
+            addGameVersion minecraft_version
+            addGameVersion 'Fabric'
 
-        mainArtifact(file("fabric/build/libs/${archives_name}-fabric-${version}.jar")) {
-            displayName = "DevWorld ${version} (Fabric)"
+            mainArtifact(project(':fabric').tasks.remapJar) {
+                displayName = "DevWorld ${version} (Fabric)"
+            }
         }
-    }
 
-    // NeoForge artifact
-    project {
-        id = curse_project_id
-        changelog = file('CHANGELOG.md')
-        releaseType = curse_release_type
+        // NeoForge artifact
+        project {
+            id = curse_project_id
+            changelog = file('CHANGELOG.md')
+            releaseType = curse_release_type
 
-        addGameVersion minecraft_version
-        addGameVersion 'NeoForge'
+            addGameVersion minecraft_version
+            addGameVersion 'NeoForge'
 
-        mainArtifact(file("neoforge/build/libs/${archives_name}-neoforge-${version}.jar")) {
-            displayName = "DevWorld ${version} (NeoForge)"
+            mainArtifact(project(':neoforge').tasks.remapJar) {
+                displayName = "DevWorld ${version} (NeoForge)"
+            }
         }
     }
 }
@@ -140,16 +143,18 @@ String readChangelogString(String filePath) {
     return ""
 }
 
-githubRelease {
-    token System.getenv("GITHUB_TOKEN") ?: "InvalidP@ssword"
-    owner System.getenv("CIRCLE_PROJECT_USERNAME") ?: ""
-    repo System.getenv("CIRCLE_PROJECT_REPONAME") ?: ""
-    targetCommitish = System.getenv("CIRCLE_SHA1") ?: ""
-    body {
-        return readChangelogString("CHANGELOG.md")
+afterEvaluate {
+    githubRelease {
+        token System.getenv("GITHUB_TOKEN") ?: "InvalidP@ssword"
+        owner System.getenv("CIRCLE_PROJECT_USERNAME") ?: ""
+        repo System.getenv("CIRCLE_PROJECT_REPONAME") ?: ""
+        targetCommitish = System.getenv("CIRCLE_SHA1") ?: ""
+        body {
+            return readChangelogString("CHANGELOG.md")
+        }
+        releaseAssets project(':fabric').tasks.remapJar.archiveFile, project(':neoforge').tasks.remapJar.archiveFile
+        overwrite true
+        tagName = version
+        releaseName = "v${version}"
     }
-    releaseAssets file("fabric/build/libs").listFiles(), file("neoforge/build/libs").listFiles()
-    overwrite true
-    tagName = version
-    releaseName = "v${version}"
 }


### PR DESCRIPTION
## Summary
Fixes the publishing configuration for the multi-module Architectury project. The curseforge and githubRelease tasks were failing because they were being configured before subproject tasks were available.

## Changes
- Wrapped `curseforge` configuration in `afterEvaluate` block
- Wrapped `githubRelease` configuration in `afterEvaluate` block  
- Changed from file paths to task references for artifacts
- Use `project(':fabric').tasks.remapJar` and `project(':neoforge').tasks.remapJar`

## Errors Fixed
**Before:**
```
Task with name 'assemble' not found in root project 'DevWorld3'
```

**After:**
The curseforge and githubRelease tasks will properly depend on the subproject build tasks and use the remapped JAR artifacts.

## Testing
This should allow the CircleCI build to successfully:
1. Build both Fabric and NeoForge artifacts
2. Upload them to CurseForge with proper display names
3. Create a GitHub release with both platform JARs attached