### PR TITLE
Fix curseforge task not building artifacts before upload

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,6 +132,12 @@ afterEvaluate {
             }
         }
     }
+
+    // Ensure curseforge task depends on building the artifacts
+    tasks.named('curseforge').configure {
+        dependsOn project(':fabric').tasks.remapJar
+        dependsOn project(':neoforge').tasks.remapJar
+    }
 }
 
 String readChangelogString(String filePath) {
@@ -156,5 +162,11 @@ afterEvaluate {
         overwrite true
         tagName = version
         releaseName = "v${version}"
+    }
+
+    // Ensure githubRelease task depends on building the artifacts
+    tasks.named('githubRelease').configure {
+        dependsOn project(':fabric').tasks.remapJar
+        dependsOn project(':neoforge').tasks.remapJar
     }
 }


### PR DESCRIPTION
## Summary
Fixes the issue where `gradle curseforge` completes with "UP-TO-DATE" without actually uploading any artifacts.

## Problem
The curseforge task was running but not building the fabric and neoforge JARs first, so it had nothing to upload. The task completed successfully but didn't publish anything.

## Solution
Added explicit task dependencies to ensure the artifacts are built before uploading:
```gradle
tasks.named('curseforge').configure {
    dependsOn project(':fabric').tasks.remapJar
    dependsOn project(':neoforge').tasks.remapJar
}

tasks.named('githubRelease').configure {
    dependsOn project(':fabric').tasks.remapJar
    dependsOn project(':neoforge').tasks.remapJar
}
```

## Testing
After this change, running `gradle curseforge` will:
1. First build the fabric remapped JAR
2. Then build the neoforge remapped JAR
3. Finally upload both to CurseForge

Same for `gradle githubRelease`.