### PR TITLE
Fix CurseForge upload - use single project block with additionalArtifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,6 @@ afterEvaluate {
     curseforge {
         apiKey = System.getenv('CURSE_API_KEY') ?: ''
 
-        // Fabric artifact
         project {
             id = curse_project_id
             changelog = file('CHANGELOG.md')
@@ -112,22 +111,13 @@ afterEvaluate {
 
             addGameVersion minecraft_version
             addGameVersion 'Fabric'
+            addGameVersion 'NeoForge'
 
             mainArtifact(project(':fabric').tasks.remapJar) {
                 displayName = "DevWorld ${version} (Fabric)"
             }
-        }
 
-        // NeoForge artifact
-        project {
-            id = curse_project_id
-            changelog = file('CHANGELOG.md')
-            releaseType = curse_release_type
-
-            addGameVersion minecraft_version
-            addGameVersion 'NeoForge'
-
-            mainArtifact(project(':neoforge').tasks.remapJar) {
+            additionalArtifact(project(':neoforge').tasks.remapJar) {
                 displayName = "DevWorld ${version} (NeoForge)"
             }
         }


### PR DESCRIPTION
## Summary
Fixes the issue where curseforge task shows "UP-TO-DATE" without actually uploading artifacts.

## Problem
The curse_gradle_uploader plugin doesn't support multiple `project {}` blocks with the same project ID. When we had two separate project blocks (one for Fabric, one for NeoForge), the plugin didn't properly handle the uploads.

## Solution
Changed to a single `project {}` block with:
- `mainArtifact` for Fabric JAR
- `additionalArtifact` for NeoForge JAR
- Both `Fabric` and `NeoForge` game versions added

```gradle
project {
    id = curse_project_id
    changelog = file('CHANGELOG.md')
    releaseType = curse_release_type

    addGameVersion minecraft_version
    addGameVersion 'Fabric'
    addGameVersion 'NeoForge'

    mainArtifact(project(':fabric').tasks.remapJar) {
        displayName = "DevWorld ${version} (Fabric)"
    }

    additionalArtifact(project(':neoforge').tasks.remapJar) {
        displayName = "DevWorld ${version} (NeoForge)"
    }
}
```

## Testing
This should allow the curseforge task to properly upload both artifacts to the same CurseForge project with the correct platform tags.