### PR TITLE
Fix CurseForge method: use addArtifact instead of additionalArtifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ afterEvaluate {
                 displayName = "DevWorld ${version} (Fabric)"
             }
 
-            additionalArtifact(project(':neoforge').tasks.remapJar) {
+            addArtifact(project(':neoforge').tasks.remapJar) {
                 displayName = "DevWorld ${version} (NeoForge)"
             }
         }


### PR DESCRIPTION
## Summary
Fixes the build error caused by using the wrong method name in the curse_gradle_uploader plugin.

## Error
```
No signature of method: info.u_team.curse_gradle_uploader.CurseProject.additionalArtifact()
Possible solutions: getAdditionalArtifacts()
```

## Fix
Changed `additionalArtifact()` to `addArtifact()` - the correct method name for adding secondary artifacts to a CurseForge project.

```gradle
// Before (wrong)
additionalArtifact(project(':neoforge').tasks.remapJar) {
    displayName = "DevWorld ${version} (NeoForge)"
}

// After (correct)
addArtifact(project(':neoforge').tasks.remapJar) {
    displayName = "DevWorld ${version} (NeoForge)"
}
```

This should allow both Fabric and NeoForge artifacts to be uploaded to CurseForge successfully.