### PR TITLE
Fix CurseForge artifacts: use archiveFile property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,11 +113,11 @@ afterEvaluate {
             addGameVersion 'Fabric'
             addGameVersion 'NeoForge'
 
-            mainArtifact(project(':fabric').tasks.remapJar) {
+            mainArtifact(project(':fabric').tasks.remapJar.archiveFile) {
                 displayName = "DevWorld ${version} (Fabric)"
             }
 
-            additionalArtifact(project(':neoforge').tasks.remapJar) {
+            addArtifact(project(':neoforge').tasks.remapJar.archiveFile) {
                 displayName = "DevWorld ${version} (NeoForge)"
             }
         }


### PR DESCRIPTION
## Summary
Fixes CurseForge upload by using the correct property to reference artifact files.

## Changes
- Use `tasks.remapJar.archiveFile` instead of just `tasks.remapJar`
- Changed `additionalArtifact` to `addArtifact` (correct method name)

The `archiveFile` property provides the actual file output from the task, which is what the curse_gradle_uploader plugin expects.

```gradle
mainArtifact(project(':fabric').tasks.remapJar.archiveFile) {
    displayName = "DevWorld ${version} (Fabric)"
}

addArtifact(project(':neoforge').tasks.remapJar.archiveFile) {
    displayName = "DevWorld ${version} (NeoForge)"
}
```